### PR TITLE
Add ghost-core and premium AI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# ai123
-122345
+# Tence AI Dashboard
+
+This project provides a minimal dashboard to visualize and control Tence AI agents.
+Open `index.html` in a browser to view the dashboard.
+
+## Premium AI
+
+An upgraded `ghost-pro` model is displayed in the dashboard. Enter the numeric
+key `1234` in the **Premium Key** field to enable the premium model.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,144 @@
+const { useState } = React;
+
+function AgentList({ agents, onSelect }) {
+  return (
+    <div id="agent-list">
+      <h3>Agents</h3>
+      <ul>
+        {agents.map(agent => (
+          <li key={agent.id} onClick={() => onSelect(agent)}>
+            <strong>{agent.name}</strong> - {agent.role} ({agent.status})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AgentModal({ agent, onClose }) {
+  if (!agent) return null;
+  return (
+    <>
+      <div className="modal-overlay" onClick={onClose}></div>
+      <div className="modal">
+        <h3>{agent.name}</h3>
+        <p><strong>Role:</strong> {agent.role}</p>
+        <p><strong>Status:</strong> {agent.status}</p>
+        <p>{agent.description}</p>
+        <button onClick={onClose}>Close</button>
+      </div>
+    </>
+  );
+}
+
+function ModelStatus({ models }) {
+  return (
+    <div id="model-status">
+      <h3>Local Model Status</h3>
+      {models.map((m, idx) => (
+        <div key={idx}>
+          <strong>{m.name}</strong> - {m.running ? 'Running' : 'Stopped'} - {m.tps} tokens/s
+          <div style={{fontSize: '0.9em', color: '#555'}}>{m.log}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Terminal({ logs, onCommand }) {
+  const [cmd, setCmd] = useState('');
+  const handleKey = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onCommand(cmd);
+      setCmd('');
+    }
+  };
+  return (
+    <div>
+      <textarea id="command-input" rows="2" value={cmd} onChange={e => setCmd(e.target.value)} onKeyDown={handleKey} placeholder="Enter command and press Enter" />
+      <div id="terminal">
+        {logs.map((l,i) => <div key={i}>{l}</div>)}
+      </div>
+    </div>
+  );
+}
+
+function Settings({ settings, onChange, onKeyChange }) {
+  const update = (field, value) => onChange({ ...settings, [field]: value });
+  return (
+    <div id="settings">
+      <h3>LLM Settings</h3>
+      <div>
+        Temperature:{' '}
+        <input
+          type="number"
+          step="0.1"
+          value={settings.temperature}
+          onChange={(e) => update('temperature', parseFloat(e.target.value))}
+        />
+      </div>
+      <div>
+        Top P:{' '}
+        <input
+          type="number"
+          step="0.1"
+          value={settings.top_p}
+          onChange={(e) => update('top_p', parseFloat(e.target.value))}
+        />
+      </div>
+      <div>
+        Max Tokens:{' '}
+        <input
+          type="number"
+          value={settings.max_tokens}
+          onChange={(e) => update('max_tokens', parseInt(e.target.value))}
+        />
+      </div>
+      <div>
+        Premium Key:{' '}
+        <input type="number" onChange={(e) => onKeyChange(e.target.value)} />
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const [agents] = useState([
+    { id: 1, name: 'Planner', role: 'Planning', status: 'Idle', description: 'Plans tasks' },
+    { id: 2, name: 'Worker', role: 'Execution', status: 'Running', description: 'Executes tasks' }
+  ]);
+  const [selected, setSelected] = useState(null);
+  const [premiumKey, setPremiumKey] = useState('');
+  const premiumEnabled = premiumKey === '1234';
+  const models = [
+    { name: 'llama.cpp', running: true, tps: 15, log: 'ready' },
+    { name: 'gguf model', running: false, tps: 0, log: 'stopped' },
+    { name: 'ghost-core (phi-2)', running: true, tps: 20, log: 'training complete' },
+    { name: 'ghost-pro', running: premiumEnabled, tps: premiumEnabled ? 30 : 0, log: premiumEnabled ? 'ready' : 'locked' }
+  ];
+  const [logs, setLogs] = useState([]);
+  const [settings, setSettings] = useState({ temperature: 0.7, top_p: 0.9, max_tokens: 512 });
+
+  const handleCommand = (cmd) => {
+    setLogs(logs => [...logs, '> '+cmd, 'Response: ...']);
+  };
+
+  return (
+    <>
+      <header>Tence AI Dashboard</header>
+      <div id="container">
+        <AgentList agents={agents} onSelect={setSelected} />
+        <div id="main">
+          <div id="knowledge-graph">Knowledge Graph Visualization</div>
+          <ModelStatus models={models} />
+          <Terminal logs={logs} onCommand={handleCommand} />
+          <Settings settings={settings} onChange={setSettings} onKeyChange={setPremiumKey} />
+        </div>
+      </div>
+      <AgentModal agent={selected} onClose={() => setSelected(null)} />
+    </>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tence AI Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,105 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f5f5f5;
+}
+
+header {
+    background: #333;
+    color: white;
+    padding: 10px;
+    text-align: center;
+}
+
+#container {
+    display: flex;
+    height: calc(100vh - 50px);
+}
+
+#agent-list {
+    width: 25%;
+    background: #fff;
+    overflow-y: auto;
+    border-right: 1px solid #ddd;
+}
+
+#agent-list ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#agent-list li {
+    padding: 10px;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+}
+
+#agent-details {
+    padding: 10px;
+}
+
+#main {
+    flex: 1;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+}
+
+#knowledge-graph {
+    flex: 1;
+    background: #fff;
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+}
+
+#model-status {
+    background: #fff;
+    border: 1px solid #ddd;
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+#terminal {
+    background: #1e1e1e;
+    color: #eee;
+    padding: 10px;
+    height: 150px;
+    overflow-y: auto;
+    font-family: monospace;
+}
+
+#command-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 5px;
+}
+
+#settings {
+    background: #fff;
+    border: 1px solid #ddd;
+    padding: 10px;
+    margin-top: 10px;
+}
+
+.modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #fff;
+    border: 1px solid #ddd;
+    padding: 20px;
+    z-index: 1000;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+}


### PR DESCRIPTION
## Summary
- document the dashboard usage and premium key in README
- add premium key field in settings
- show ghost-core and premium AI models in dashboard

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684bde4ccbb8832e94f7b3e9092cbd02