### PR TITLE
Add Tence AI offline app

### DIFF
--- a/tence_ai.py
+++ b/tence_ai.py
@@ -1,0 +1,121 @@
+import os
+import json
+import subprocess
+import sys
+
+
+def ensure_packages():
+    """Install required packages if they are missing."""
+    try:
+        import transformers  # noqa: F401
+        import torch  # noqa: F401
+        import gradio  # noqa: F401
+    except ImportError:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "transformers",
+                "torch",
+                "gradio",
+            ]
+        )
+
+    try:
+        import transformers  # noqa: F401
+        import torch  # noqa: F401
+        import gradio  # noqa: F401
+    except ImportError:
+        print(
+            "Required packages are not installed. Please install them manually in your offline environment."
+        )
+        raise
+
+
+ensure_packages()
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+import gradio as gr
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+dtype = torch.float16 if torch.cuda.is_available() else torch.float32
+
+MODEL_PATH = "ghost-core-lora"
+USER_FILE = "user_data.json"
+MAX_FREE_TURNS = 5
+PREMIUM_CODE = "TENCEPRO2025"
+
+# Load or initialize user data
+if os.path.exists(USER_FILE):
+    with open(USER_FILE, "r") as f:
+        user_data = json.load(f)
+else:
+    user_data = {"premium": False}
+
+use_count = 0
+
+
+def save_user_data():
+    with open(USER_FILE, "w") as f:
+        json.dump(user_data, f)
+
+
+def load_model():
+    if not os.path.exists(MODEL_PATH):
+        raise FileNotFoundError(
+            f"Model path '{MODEL_PATH}' not found. Ensure the phi-3 model is saved under this directory."
+        )
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+    model = AutoModelForCausalLM.from_pretrained(MODEL_PATH, torch_dtype=dtype)
+    model.to(device)
+    return tokenizer, model
+
+
+tokenizer, model = load_model()
+
+
+def chat(message, code, history, depth):
+    global use_count
+    if code and code.strip() == PREMIUM_CODE:
+        user_data["premium"] = True
+        save_user_data()
+    premium = user_data.get("premium", False)
+    if not premium and use_count >= MAX_FREE_TURNS:
+        history.append(("System", "Please enter the authorization code to continue."))
+        return history, "", code, history
+    use_count += 1
+    relevant = history[-int(depth):] if depth else history
+    prompt = ""
+    for u, a in relevant:
+        prompt += f"User: {u}\nAssistant: {a}\n"
+    prompt += f"User: {message}\nAssistant:"
+    inputs = tokenizer(prompt, return_tensors="pt").to(device)
+    max_tokens = 200 if premium else 50
+    outputs = model.generate(**inputs, max_new_tokens=max_tokens, do_sample=True)
+    response = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    if "Assistant:" in response:
+        response = response.split("Assistant:")[-1].strip()
+    history.append((message, response))
+    return history, "", code, history
+
+
+def main():
+    with gr.Blocks() as demo:
+        gr.Markdown("# Tence AI")
+        state = gr.State([])
+        chatbot = gr.Chatbot()
+        with gr.Row():
+            txt = gr.Textbox(label="Question", placeholder="Ask anything")
+            auth = gr.Textbox(label="Auth Code", placeholder="Enter code if available")
+        depth = gr.Slider(1, 10, value=3, step=1, label="Memory Depth")
+        send = gr.Button("Send")
+        send.click(chat, [txt, auth, state, depth], [chatbot, txt, auth, state])
+        txt.submit(chat, [txt, auth, state, depth], [chatbot, txt, auth, state])
+    demo.launch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tence_ai.py` implementing offline chat with microsoft/phi-3-mini-4k-instruct model stored in `ghost-core-lora`
- include Gradio UI with chat history, auth code input, and memory-depth slider
- add runtime package installer that prompts to manually install packages if offline
- track free user limits and store premium status in `user_data.json`

## Testing
- `python tence_ai.py --help` *(fails: required packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ca05b9df8832eb2c747dcb5b5f044